### PR TITLE
[FIX] add missing "Battery Status: " text if wifi is on

### DIFF
--- a/Firmware.ino
+++ b/Firmware.ino
@@ -117,7 +117,7 @@ void loop(){
           strcat(sendsmstext, "h\n");
           strcat(sendsmstext,"Wifi Status: ");  
           if(iswifion){
-            strcat(sendsmstext,"on\n");
+            strcat(sendsmstext,"on\nBattery Status: ");
           }else{
             strcat(sendsmstext,"off\nBattery Status: ");
           }


### PR DESCRIPTION
Previously, the app couldn't parse sms messages if the wifi was on, e.g.
```
Warningnumber: no number set
Interval: 1h
Wifi Status: on
98%
```
because the "Battery Status: " was missing from the last line.